### PR TITLE
Hotfix – Login titel gewijzigd

### DIFF
--- a/Grocery.App/Views/LoginView.xaml
+++ b/Grocery.App/Views/LoginView.xaml
@@ -6,7 +6,7 @@
              x:DataType="vm:LoginViewModel"
              Title="LoginView">
     <StackLayout Padding="20" VerticalOptions="Center">
-        <Label Text="Login" FontSize="24" HorizontalOptions="Center" />
+        <Label Text="Inloggen op een bestaand account" FontSize="24" HorizontalOptions="Center" />
         <Entry Placeholder="Email" Text="{Binding Email}" Keyboard="Email" />
         <Entry Placeholder="Password" Text="{Binding Password}" IsPassword="True" />
         <Button Text="Login" Command="{Binding LoginCommand}" />


### PR DESCRIPTION
## Changes
* Om meer duidelijkheid te creëren op de login pagina is de login titel gewijzigd van 'Login' naar 'Inloggen op een bestaand account'. Daarnaast is de hoofdreden van de wijziging het laten zien dat ik correct gebruik maak van de hotfix branch. 